### PR TITLE
Resolve differences with gcoap

### DIFF
--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -280,8 +280,10 @@ size_t coap_put_option_url(uint8_t *buf, uint16_t lastonum, const char *url)
 
         part_len = (uint8_t*)urlpos - part_start;
 
-        bufpos += coap_put_option(bufpos, lastonum, COAP_OPT_URL, part_start, part_len);
-        lastonum = COAP_OPT_URL;
+        if (part_len) {
+            bufpos += coap_put_option(bufpos, lastonum, COAP_OPT_URL, part_start, part_len);
+            lastonum = COAP_OPT_URL;
+        }
     }
 
     return bufpos - buf;

--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -246,10 +246,10 @@ size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, uint8_t *
 
 size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum, uint16_t content_type)
 {
-    if (!content_type) {
-        return 0;
+    if (content_type == 0) {
+        return coap_put_option(buf, lastonum, COAP_OPT_CT, NULL, 0);
     }
-    if (content_type <= 255) {
+    else if (content_type <= 255) {
         uint8_t tmp = content_type;
         return coap_put_option(buf, lastonum, COAP_OPT_CT, &tmp, sizeof(tmp));
     }

--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -33,6 +33,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     uint8_t *pkt_end = buf + len;
 
     memset(pkt->url, '\0', NANOCOAP_URL_MAX);
+    pkt->payload_len = 0;
 
     /* token value (tkl bytes) */
     pkt_pos += coap_get_token_len(pkt);

--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -36,7 +36,12 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     pkt->payload_len = 0;
 
     /* token value (tkl bytes) */
-    pkt_pos += coap_get_token_len(pkt);
+    if (coap_get_token_len(pkt)) {
+        pkt->token = pkt_pos;
+        pkt_pos += coap_get_token_len(pkt);
+    } else {
+        pkt->token = NULL;
+    }
 
     /* parse options */
     int option_nr = 0;

--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -74,9 +74,11 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
                     urlpos += option_len;
                     break;
                 case COAP_OPT_CT:
-                    if (option_len == 1) {
+                    if (option_len == 0) {
+                        pkt->content_type = 0;
+                    } else if (option_len == 1) {
                         pkt->content_type = *pkt_pos;
-                    } else {
+                    } else if (option_len == 2) {
                         memcpy(&pkt->content_type, pkt_pos, 2);
                         pkt->content_type = ntohs(pkt->content_type);
                     }

--- a/nanocoap/nanocoap.h
+++ b/nanocoap/nanocoap.h
@@ -10,15 +10,28 @@
 #define NANOCOAP_URL_MAX        (64)
 
 #define COAP_OPT_URL            (11)
+#define COAP_OPT_URI_PATH       (11)
 #define COAP_OPT_CT             (12)
+#define COAP_OPT_CONTENT_FORMAT (12)
 
 #define COAP_REQ                (0)
 #define COAP_RESP               (2)
 
 /**
+ * @name Message types -- confirmable, non-confirmable, etc.
+ * @{
+ */
+#define COAP_TYPE_CON           (0)
+#define COAP_TYPE_NON           (1)
+#define COAP_TYPE_ACK           (2)
+#define COAP_TYPE_RST           (3)
+/** @} */
+
+/**
  * @name CoAP method codes used in header
  * @{
  */
+#define COAP_CLASS_REQ          (0)
 #define COAP_METHOD_GET         (1)
 #define COAP_METHOD_POST        (2)
 #define COAP_METHOD_PUT         (3)
@@ -35,14 +48,66 @@
 #define COAP_DELETE             (0x8)
 /** @} */
 
-#define COAP_CODE_205           ((2<<5) | 5)
-#define COAP_CODE_404           ((4<<5) | 4)
+/**
+ * @name Response message codes: success
+ * @{
+ */
+#define COAP_CLASS_SUCCESS      (2)
+#define COAP_CODE_CREATED      ((2<<5) | 1)
+#define COAP_CODE_DELETED      ((2<<5) | 2)
+#define COAP_CODE_VALID        ((2<<5) | 3)
+#define COAP_CODE_CHANGED      ((2<<5) | 4)
+#define COAP_CODE_CONTENT      ((2<<5) | 5)
+#define COAP_CODE_205          ((2<<5) | 5)
+/** @} */
+/**
+ * @name Response message codes: client error
+ * @{
+ */
+#define COAP_CLASS_CLIENT_FAILURE             (4)
+#define COAP_CODE_BAD_REQUEST                ((4<<5) | 0)
+#define COAP_CODE_UNAUTHORIZED               ((4<<5) | 1)
+#define COAP_CODE_BAD_OPTION                 ((4<<5) | 2)
+#define COAP_CODE_FORBIDDEN                  ((4<<5) | 3)
+#define COAP_CODE_PATH_NOT_FOUND             ((4<<5) | 4)
+#define COAP_CODE_404                        ((4<<5) | 4)
+#define COAP_CODE_METHOD_NOT_ALLOWED         ((4<<5) | 5)
+#define COAP_CODE_NOT_ACCEPTABLE             ((4<<5) | 6)
+#define COAP_CODE_PRECONDITION_FAILED        ((4<<5) | 0xC)
+#define COAP_CODE_REQUEST_ENTITY_TOO_LARGE   ((4<<5) | 0xD)
+#define COAP_CODE_UNSUPPORTED_CONTENT_FORMAT ((4<<5) | 0xF)
+/** @} */
+/**
+ * @name Response message codes: server error
+ * @{
+ */
+#define COAP_CLASS_SERVER_FAILURE             (5)
+#define COAP_CODE_INTERNAL_SERVER_ERROR      ((5<<5) | 0)
+#define COAP_CODE_NOT_IMPLEMENTED            ((5<<5) | 1)
+#define COAP_CODE_BAD_GATEWAY                ((5<<5) | 2)
+#define COAP_CODE_SERVICE_UNAVAILABLE        ((5<<5) | 3)
+#define COAP_CODE_GATEWAY_TIMEOUT            ((5<<5) | 4)
+#define COAP_CODE_PROXYING_NOT_SUPPORTED     ((5<<5) | 5)
+/** @} */
 
 #define COAP_CT_LINK_FORMAT     (40)
 #define COAP_CT_XML             (41)
 #define COAP_CT_OCTET_STREAM    (42)
 #define COAP_CT_EXI             (47)
 #define COAP_CT_JSON            (50)
+
+/**
+ * @name Content-Format option codes
+ * @{
+ */
+#define COAP_FORMAT_TEXT         (0)
+#define COAP_FORMAT_LINK        (40)
+#define COAP_FORMAT_OCTET       (42)
+#define COAP_FORMAT_JSON        (50)
+#define COAP_FORMAT_CBOR        (60)
+/** @brief nanocoap-specific value to indicate no format specified. */
+#define COAP_FORMAT_NONE     (65535)
+/** @} */
 
 #define COAP_ACK_TIMEOUT        (2U)
 #define COAP_RANDOM_FACTOR      (1.5)


### PR DESCRIPTION
Commits from 9f0eed6 through 8b67907 are fixes/improvements, and should not be controversial.

Commit 0a7faba includes some improvements and also some more stylistic differences. In general I prefer constants that are spelled out more and based on the RFC. I expect this choice will make it easier for a reader to follow the logic, even though a longer constant makes it harder to use a single line for a statement. Aside from these differences, I really like your use of doxygen to group #defines!

Below are specific comments, from top to bottom:

1. COAP_OPT -- _URL can be confusing, because there also is a Uri-Query option. _CT is confusing because the option is Content-Format. I suggest using _CF, or _CONTENT_FORMAT, as I have done. 
2. COAP_TYPE -- There is nothing comparable in nanocoap for these values.
3. COAP_CLASS -- I like these for grouping codes.
4. COAP_CODE -- I added all of the constants from the RFC. Use of numeric names like _404 or _205 may be OK for well-known values, but I think it gets cryptic beyond them.
5. COAP_FORMAT -- Once again, I like to spell these out. If you're opposed to them, please at least at COAP_CT_CBOR and COAP_CT_NONE. 