### PR TITLE
Uri-Host is a critical option; don't ignore it.

### DIFF
--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -72,9 +72,6 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
             DEBUG("option nr=%i len=%i\n", option_nr, option_len);
 
             switch (option_nr) {
-                case COAP_OPT_URI_HOST:
-                    DEBUG("nanocoap: ignoring Uri-Host option!\n");
-                    break;
                 case COAP_OPT_URI_PATH:
                     *urlpos++ = '/';
                     memcpy(urlpos, pkt_pos, option_len);


### PR DESCRIPTION
Since Uri-Host is a[ critical option](https://tools.ietf.org/html/rfc7252#section-5.4.1), an implementation must not ignore it. This PR handles this immediate need.

The key then is to ensure the client does not send a Uri-Host option. I feel your pain on this one, specifically with the libcoap examples. :-) So, I just created a [PR](https://github.com/obgm/libcoap/pull/52) to ensure this option is not sent.