### PR TITLE
nanocoap: fix sock_udp_ep_t remote init

### DIFF
--- a/nanocoap/nanocoap_sock.c
+++ b/nanocoap/nanocoap_sock.c
@@ -88,7 +88,7 @@ out:
 int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize)
 {
     sock_udp_t sock;
-    sock_udp_ep_t remote = { 0 };
+    sock_udp_ep_t remote;
 
     if (!local->port) {
         local->port = COAP_PORT;


### PR DESCRIPTION
This fixes the following error on macOS when building with `nanocoap` dependency:

```
.../RIOT/tests/unittests/bin/pkg/native/nanocoap/nanocoap/nanocoap_sock.c:91:32: error: missing field 'addr' initializer
      [-Werror,-Wmissing-field-initializers]
    sock_udp_ep_t remote = { 0 };
                               ^
1 error generated.
```