### PR TITLE
Add additional parameter to COAP handler functions

### DIFF
--- a/nanocoap/handler.c
+++ b/nanocoap/handler.c
@@ -3,9 +3,9 @@
 
 #include "nanocoap.h"
 
-ssize_t _test_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len)
+ssize_t _test_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, void *param)
 {
-    printf("_test_handler()\n");
+    printf("_test_handler(%d)\n", (int)param);
     printf("coap pkt parsed. code=%u detail=%u payload_len=%u, len=%u 0x%02x\n",
             coap_get_code_class(pkt),
             coap_get_code_detail(pkt),
@@ -17,7 +17,7 @@ ssize_t _test_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len)
 
 const coap_resource_t coap_resources[] = {
     COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER,
-    { "/test", COAP_GET, _test_handler },
+    { "/test", COAP_GET, _test_handler, (void*)0 },
 };
 
 const unsigned coap_resources_numof = sizeof(coap_resources) / sizeof(coap_resources[0]);

--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -146,7 +146,8 @@ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_le
             break;
         }
         else {
-            return coap_resources[i].handler(pkt, resp_buf, resp_buf_len);
+            return coap_resources[i].handler(pkt, resp_buf, resp_buf_len,
+                coap_resources[i].parameter);
         }
     }
 
@@ -345,8 +346,10 @@ size_t coap_put_option_url(uint8_t *buf, uint16_t lastonum, const char *url)
 }
 
 ssize_t coap_well_known_core_default_handler(coap_pkt_t* pkt, uint8_t *buf, \
-                                             size_t len)
+                                             size_t len, void *ignored)
 {
+    (void)ignored;
+
     uint8_t *payload = buf + coap_get_total_hdr_len(pkt);
 
     uint8_t *bufpos = payload;

--- a/nanocoap/nanocoap.h
+++ b/nanocoap/nanocoap.h
@@ -144,12 +144,13 @@ typedef struct {
     uint32_t observe_value;
 } coap_pkt_t;
 
-typedef ssize_t (*coap_handler_t)(coap_pkt_t* pkt, uint8_t *buf, size_t len);
+typedef ssize_t (*coap_handler_t)(coap_pkt_t* pkt, uint8_t *buf, size_t len, void *param);
 
 typedef struct {
     const char *path;
     unsigned methods;
     coap_handler_t handler;
+    void *parameter;
 } coap_resource_t;
 
 extern const coap_resource_t coap_resources[];
@@ -261,7 +262,8 @@ static inline uint32_t coap_get_observe(coap_pkt_t *pkt)
 }
 
 extern ssize_t coap_well_known_core_default_handler(coap_pkt_t* pkt, \
-                                                    uint8_t *buf, size_t len);
+                                                    uint8_t *buf, size_t len,
+                                                    void *param);
 
 #define COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER \
     { "/.well-known/core", COAP_GET, coap_well_known_core_default_handler }


### PR DESCRIPTION
Adds a new additional `void *` parameter to the handler functions.  This makes it easier to write handlers functions that handle multiple URLs, e.g. a single function is enough to read multiple I/O pins.