### PR TITLE
Feature nanocoap add resource to handler

### DIFF
--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -146,7 +146,7 @@ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_le
             break;
         }
         else {
-            return coap_resources[i].handler(pkt, resp_buf, resp_buf_len);
+            return coap_resources[i].handler(pkt, resp_buf, resp_buf_len, &coap_resources[i]);
         }
     }
 

--- a/nanocoap/nanocoap.h
+++ b/nanocoap/nanocoap.h
@@ -144,7 +144,7 @@ typedef struct {
     uint32_t observe_value;
 } coap_pkt_t;
 
-typedef ssize_t (*coap_handler_t)(coap_pkt_t* pkt, uint8_t *buf, size_t len);
+typedef ssize_t (*coap_handler_t)(coap_pkt_t* pkt, uint8_t *buf, size_t len, ...);
 
 typedef struct {
     const char *path;


### PR DESCRIPTION
@kaspar030 This is now a minimal alternative to #12.  In fact, 09f4ff8 is all I need since now I'm using gcoap, not directly nanocoap.  But I think b73efd6 makes sense, too.  There lingers still the problem that it should be easy to extend `coap_resource_t`, but I can live with this for now.

Of course, 09f4ff8 *may* not work with older compilers.  If that is a priority, then it probably will need to be guarded with a suitable `#ifdef`.