### PR TITLE
nanocoap: add Uri-Query handling capabilities

### DIFF
--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -313,31 +313,32 @@ size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum, uint16_t content_type
     }
 }
 
-size_t coap_put_option_url(uint8_t *buf, uint16_t lastonum, const char *url)
+size_t coap_put_option_uri(uint8_t *buf, uint16_t lastonum, const char *uri, uint16_t optnum)
 {
-    size_t url_len = strlen(url);
-    assert(url_len);
+    char seperator = (optnum == COAP_OPT_URI_PATH) ? '/' : '&';
+    size_t uri_len = strlen(uri);
+    assert(uri_len);
 
     uint8_t *bufpos = buf;
-    char *urlpos = (char*)url;
+    char *uripos = (char*)uri;
 
-    while(url_len) {
+    while(uri_len) {
         size_t part_len;
-        urlpos++;
-        uint8_t *part_start = (uint8_t*)urlpos;
+        uripos++;
+        uint8_t *part_start = (uint8_t*)uripos;
 
-        while (url_len--) {
-            if ((*urlpos == '/') || (*urlpos == '\0')) {
+        while (uri_len--) {
+            if ((*uripos == seperator) || (*uripos == '\0')) {
                 break;
             }
-            urlpos++;
+            uripos++;
         }
 
-        part_len = (uint8_t*)urlpos - part_start;
+        part_len = (uint8_t*)uripos - part_start;
 
         if (part_len) {
-            bufpos += coap_put_option(bufpos, lastonum, COAP_OPT_URI_PATH, part_start, part_len);
-            lastonum = COAP_OPT_URI_PATH;
+            bufpos += coap_put_option(bufpos, lastonum, optnum, part_start, part_len);
+            lastonum = optnum;
         }
     }
 

--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -315,7 +315,7 @@ size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum, uint16_t content_type
 
 size_t coap_put_option_uri(uint8_t *buf, uint16_t lastonum, const char *uri, uint16_t optnum)
 {
-    char seperator = (optnum == COAP_OPT_URI_PATH) ? '/' : '&';
+    char separator = (optnum == COAP_OPT_URI_PATH) ? '/' : '&';
     size_t uri_len = strlen(uri);
     assert(uri_len);
 
@@ -328,7 +328,7 @@ size_t coap_put_option_uri(uint8_t *buf, uint16_t lastonum, const char *uri, uin
         uint8_t *part_start = (uint8_t*)uripos;
 
         while (uri_len--) {
-            if ((*uripos == seperator) || (*uripos == '\0')) {
+            if ((*uripos == separator) || (*uripos == '\0')) {
                 break;
             }
             uripos++;

--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -317,7 +317,9 @@ size_t coap_put_option_uri(uint8_t *buf, uint16_t lastonum, const char *uri, uin
 {
     char separator = (optnum == COAP_OPT_URI_PATH) ? '/' : '&';
     size_t uri_len = strlen(uri);
-    assert(uri_len);
+    if (uri_len == 0) {
+        return 0;
+    }
 
     uint8_t *bufpos = buf;
     char *uripos = (char*)uri;

--- a/nanocoap/nanocoap.h
+++ b/nanocoap/nanocoap.h
@@ -9,11 +9,13 @@
 
 #define COAP_PORT               (5683)
 #define NANOCOAP_URL_MAX        (64)
+#define NANOCOAP_QS_MAX         (64)
 
 #define COAP_OPT_URI_HOST       (3)
 #define COAP_OPT_OBSERVE        (6)
 #define COAP_OPT_URI_PATH       (11)
 #define COAP_OPT_CONTENT_FORMAT (12)
+#define COAP_OPT_URI_QUERY      (15)
 
 #define COAP_REQ                (0)
 #define COAP_RESP               (2)
@@ -137,6 +139,7 @@ typedef struct {
 typedef struct {
     coap_hdr_t *hdr;
     uint8_t url[NANOCOAP_URL_MAX];
+    uint8_t qs[NANOCOAP_QS_MAX];
     uint8_t *token;
     uint8_t *payload;
     unsigned payload_len;
@@ -170,7 +173,7 @@ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_le
 ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, uint8_t *token, size_t token_len, unsigned code, uint16_t id);
 size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, uint8_t *odata, size_t olen);
 size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum, uint16_t content_type);
-size_t coap_put_option_url(uint8_t *buf, uint16_t lastonum, const char *url);
+size_t coap_put_option_uri(uint8_t *buf, uint16_t lastonum, const char *uri, uint16_t optnum);
 
 static inline unsigned coap_get_ver(coap_pkt_t *pkt)
 {

--- a/nanocoap/nanocoap_sock.c
+++ b/nanocoap/nanocoap_sock.c
@@ -28,7 +28,7 @@ ssize_t nanocoap_get(sock_udp_ep_t *remote, const char *path, uint8_t *buf, size
 
     uint8_t *pktpos = buf;
     pktpos += coap_build_hdr((coap_hdr_t *)pktpos, COAP_REQ, NULL, 0, COAP_METHOD_GET, 1);
-    pktpos += coap_put_option_url(pktpos, 0, path);
+    pktpos += coap_put_option_uri(pktpos, 0, path, COAP_OPT_URI_PATH);
 
     /* TODO: timeout random between between ACK_TIMEOUT and (ACK_TIMEOUT *
      * ACK_RANDOM_FACTOR) */


### PR DESCRIPTION
Uri-query strings are needed for e.g. `lwm2m` or CoAP resource directories (RD). This PR adds the capability to add `COAP_OPT_URI_QUERY` options to CoAP requests.

This PR adds an additional buffer to hold the raw query string in the `coap_pkt_t` structure. The alternative would be to write the query string into the `url` buffer, but this would make the parsing of options quite a bit harder, so I went with this (for now?!).