### PR TITLE
nanocoap: added function for finding options

### DIFF
--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -412,7 +412,7 @@ static int _parse_opt(uint8_t *optpos, coap_opt_t *opt)
     return (opt->val - optpos) + opt->len;
 }
 
-uint8_t *coap_find_option(coap_pkt_t *pkt, uint8_t *bufpos,
+uint8_t *coap_find_option(uint8_t *payload_pos, uint8_t *bufpos,
                           coap_opt_t *opt, uint16_t optnum)
 {
     assert(opt);
@@ -425,7 +425,7 @@ uint8_t *coap_find_option(coap_pkt_t *pkt, uint8_t *bufpos,
     uint16_t delta = 0;
 
     do {
-        if (bufpos >= pkt->payload) {
+        if (bufpos >= payload_pos) {
             return NULL;
         }
         int res = _parse_opt(bufpos, opt);

--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -50,6 +50,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     }
 
     /* parse options */
+    pkt->options = (pkt_pos != pkt_end) ? pkt_pos : NULL;
     int option_nr = 0;
     while (pkt_pos != pkt_end) {
         uint8_t option_byte = *pkt_pos++;
@@ -107,6 +108,13 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
 
             pkt_pos += option_len;
         }
+    }
+
+    /* set payload pointer to first byte after the options in case no payload
+     * is present, so we can use it as reference to find the end of options
+     * at a later point in time */
+    if (pkt_pos == pkt_end) {
+        pkt->payload = pkt_end;
     }
 
     DEBUG("coap pkt parsed. code=%u detail=%u payload_len=%u, 0x%02x\n",
@@ -368,4 +376,66 @@ ssize_t coap_well_known_core_default_handler(coap_pkt_t* pkt, uint8_t *buf, \
     unsigned payload_len = bufpos - payload;
 
     return coap_build_reply(pkt, COAP_CODE_205, buf, len, payload_len);
+}
+
+size_t get_lenval(uint8_t *buf, uint16_t *val)
+{
+    size_t len = 0;
+
+    if (*val == 13) {
+        *val += *buf;
+        len = 1;
+    }
+    else if (*val == 14) {
+        memcpy(val, buf, 2);
+        *val = htons(*val) + 269;
+        len = 2;
+    }
+
+    return len;
+}
+
+int parse_opt(uint8_t *optpos, coap_opt_t *opt)
+{
+    opt->val = optpos + 1;
+    opt->delta = ((*optpos & 0xf0) >> 4);
+    opt->len =  (*optpos & 0x0f);
+
+    /* make sure delta and len raw values are valid */
+    if ((opt->delta == 15) || (opt->len == 15)) {
+        return -1;
+    }
+
+    opt->val += get_lenval(opt->val, &opt->delta);
+    opt->val += get_lenval(opt->val, &opt->len);
+
+    return (opt->val - optpos) + opt->len;
+}
+
+uint8_t *coap_find_opt(coap_pkt_t *pkt, uint8_t *bufpos,
+                       coap_opt_t *opt, uint16_t optnum)
+{
+    assert(opt);
+
+    /* check if we reached the end of options */
+    if (!bufpos || (*bufpos == 0xff) || (bufpos == pkt->payload)) {
+        return NULL;
+    }
+
+    uint16_t delta = 0;
+
+    do {
+        int res = parse_opt(bufpos, opt);
+        if (res < 0) {
+            return NULL;
+        }
+        bufpos += res;
+        delta += opt->delta;
+    } while (delta < optnum);
+
+    if (delta != optnum) {
+        bufpos = NULL;
+    }
+
+    return bufpos;
 }

--- a/nanocoap/nanocoap.h
+++ b/nanocoap/nanocoap.h
@@ -183,7 +183,7 @@ size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, uint8_t *
 size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum, uint16_t content_type);
 size_t coap_put_option_uri(uint8_t *buf, uint16_t lastonum, const char *uri, uint16_t optnum);
 
-uint8_t *coap_find_opt(coap_pkt_t *pkt, uint8_t *bufpos, coap_opt_t *opt, uint16_t optnum);
+uint8_t *coap_find_option(coap_pkt_t *pkt, uint8_t *bufpos, coap_opt_t *opt, uint16_t optnum);
 
 static inline unsigned coap_get_ver(coap_pkt_t *pkt)
 {

--- a/nanocoap/nanocoap.h
+++ b/nanocoap/nanocoap.h
@@ -13,6 +13,7 @@
 
 #define COAP_OPT_URI_HOST       (3)
 #define COAP_OPT_OBSERVE        (6)
+#define COAP_OPT_LOCATION_PATH  (8)
 #define COAP_OPT_URI_PATH       (11)
 #define COAP_OPT_CONTENT_FORMAT (12)
 #define COAP_OPT_URI_QUERY      (15)
@@ -141,6 +142,7 @@ typedef struct {
     uint8_t url[NANOCOAP_URL_MAX];
     uint8_t qs[NANOCOAP_QS_MAX];
     uint8_t *token;
+    uint8_t *options;
     uint8_t *payload;
     unsigned payload_len;
     uint16_t content_type;
@@ -154,6 +156,12 @@ typedef struct {
     unsigned methods;
     coap_handler_t handler;
 } coap_resource_t;
+
+typedef struct {
+    uint16_t delta;
+    uint16_t len;
+    uint8_t *val;
+} coap_opt_t;
 
 extern const coap_resource_t coap_resources[];
 extern const unsigned coap_resources_numof;
@@ -174,6 +182,8 @@ ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, uint8_t *token, size_t to
 size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, uint8_t *odata, size_t olen);
 size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum, uint16_t content_type);
 size_t coap_put_option_uri(uint8_t *buf, uint16_t lastonum, const char *uri, uint16_t optnum);
+
+uint8_t *coap_find_opt(coap_pkt_t *pkt, uint8_t *bufpos, coap_opt_t *opt, uint16_t optnum);
 
 static inline unsigned coap_get_ver(coap_pkt_t *pkt)
 {

--- a/nanocoap/nanocoap.h
+++ b/nanocoap/nanocoap.h
@@ -183,7 +183,7 @@ size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, uint8_t *
 size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum, uint16_t content_type);
 size_t coap_put_option_uri(uint8_t *buf, uint16_t lastonum, const char *uri, uint16_t optnum);
 
-uint8_t *coap_find_option(coap_pkt_t *pkt, uint8_t *bufpos, coap_opt_t *opt, uint16_t optnum);
+uint8_t *coap_find_option(uint8_t *payload_pos, uint8_t *bufpos, coap_opt_t *opt, uint16_t optnum);
 
 static inline unsigned coap_get_ver(coap_pkt_t *pkt)
 {


### PR DESCRIPTION
After receiving a packet, I needed to be able to read out certain options (`COAP_OPT_LOCATION_PATH` in my case), and to copy their content into some user defined buffers. This was not able with the current interface, so I added a function that allows for finding certain options.

The usage is quite easy (I hope):
```c
coap_opt_t *opt;

// for finding the first occurrence of a certain option:
uint8_t *bufpos = coap_find_opt(pdu, pdu->options, &opt, COAP_OPT_LOCATION_PATH);

// for finding the next occurrence of the same option:
while (bufpos) {
    bufpos = coap_find_opt(pdu, bufpos, &opt, 0);
    ...
}
```

With this function one can read ANY option and do with its values whatever they like...