### PR TITLE
nanocoap: added coap_get_code_raw()

### DIFF
--- a/nanocoap/nanocoap.h
+++ b/nanocoap/nanocoap.h
@@ -197,6 +197,11 @@ static inline unsigned coap_get_code_detail(coap_pkt_t *pkt)
     return pkt->hdr->code & 0x1f;
 }
 
+static inline unsigned coap_get_code_raw(coap_pkt_t *pkt)
+{
+    return (unsigned)pkt->hdr->code;
+}
+
 static inline unsigned coap_get_code(coap_pkt_t *pkt)
 {
     return (coap_get_code_class(pkt) * 100) + coap_get_code_detail(pkt);


### PR DESCRIPTION
as discussed in https://github.com/RIOT-OS/RIOT/pull/7413

using the raw function to compare the code against a pre-defined values saves some computations compared to using `coap_get_code()`.