### PR TITLE
nanocoap: Add blockwise transfer block2 support

### DIFF
--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -108,8 +108,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
                         pkt->block2_size = (COAP_BLOCKWISE_SZX_MAX > blk2_size) ?
                             blk2_size :
                             COAP_BLOCKWISE_SZX_MAX;
-                        if (pkt->block2_size > 10)
-                        {
+                        if (pkt->block2_size > 10) {
                             DEBUG("nanocoap: discarding packet with invalid block szx.\n");
                             return -EBADMSG;
                         }
@@ -338,7 +337,8 @@ size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum, uint16_t content_type
     }
 }
 
-size_t coap_put_option_block2(uint8_t *buf, uint16_t lastonum, coap_blockwise_t *blk)
+size_t coap_put_option_block2(uint8_t *buf, uint16_t lastonum, \
+                              coap_blockwise_t *blk)
 {
     size_t opt_len = 1;
     uint32_t tmp = 0;
@@ -353,22 +353,20 @@ size_t coap_put_option_block2(uint8_t *buf, uint16_t lastonum, coap_blockwise_t 
     }
 
     /* Determine option length */
-    if (num > 0x0f)
-    {
+    if (num > 0x0f) {
         opt_len = 2;
     }
-    else if (num > 0x0fff)
-    {
+    else if (num > 0x0fff) {
         opt_len = 3;
     }
 
     tmp = num << COAP_BLOCKWISE_NUM_OFF;
-    if (blk->cur_pos >= blk->end_pos)
-    {
+    if (blk->cur_pos >= blk->end_pos) {
         tmp |= 1 << COAP_BLOCKWISE_MORE_OFF;
     }
     tmp |= szx;
-    return coap_put_option(blk->block_hdr, lastonum, COAP_OPT_BLOCK2, (uint8_t*)&tmp, opt_len);
+    return coap_put_option(blk->block_hdr, lastonum, COAP_OPT_BLOCK2, 
+                           (uint8_t*)&tmp, opt_len);
 }
 
 size_t coap_put_option_uri(uint8_t *buf, uint16_t lastonum, const char *uri, uint16_t optnum)
@@ -415,10 +413,8 @@ void coap_blockwise_init(coap_pkt_t *pkt, coap_blockwise_t *blk)
 
 size_t coap_blockwise_put_char(uint8_t *bufpos, coap_blockwise_t *blk, char c)
 {
-    if (blk->start_pos <=  blk->cur_pos)
-    {
-        if (blk->cur_pos >= blk->end_pos)
-        {
+    if (blk->start_pos <=  blk->cur_pos) {
+        if (blk->cur_pos >= blk->end_pos) {
             blk->cur_pos++;
             return 0;
         }
@@ -430,7 +426,8 @@ size_t coap_blockwise_put_char(uint8_t *bufpos, coap_blockwise_t *blk, char c)
     return 0;
 }
 
-size_t coap_blockwise_put_string(uint8_t *bufpos, coap_blockwise_t *blk, const char *c, size_t len)
+size_t coap_blockwise_put_string(uint8_t *bufpos, coap_blockwise_t *blk, \
+                                 const char *c, size_t len)
 {
     uint16_t str_offset = 0;
     uint16_t str_len = 0;
@@ -478,7 +475,8 @@ ssize_t coap_well_known_core_default_handler(coap_pkt_t* pkt, uint8_t *buf, \
         }
         unsigned url_len = strlen(coap_resources[i].path);
         bufpos += coap_blockwise_put_char(bufpos, &blk, '<');
-        bufpos += coap_blockwise_put_string(bufpos, &blk, coap_resources[i].path, url_len);
+        bufpos += coap_blockwise_put_string(bufpos, &blk, \
+                                            coap_resources[i].path, url_len);
         bufpos += coap_blockwise_put_char(bufpos, &blk, '>');
     }
 

--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -39,8 +39,6 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
 
     memset(pkt->url, '\0', NANOCOAP_URL_MAX);
     pkt->payload_len = 0;
-    pkt->block2_size = COAP_BLOCKWISE_SZX_MAX;
-    pkt->block2_num = 0;
     pkt->observe_value = UINT32_MAX;
 
     /* token value (tkl bytes) */
@@ -104,11 +102,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
                     if (option_len < 4) {
                         uint32_t blk2_opt = _decode_uint(pkt_pos, option_len);
                         uint8_t blk2_size = (blk2_opt & COAP_BLOCKWISE_SZX_MASK) + 4;
-                        pkt->block2_num = blk2_opt >> COAP_BLOCKWISE_NUM_OFF;
-                        pkt->block2_size = (COAP_BLOCKWISE_SZX_MAX > blk2_size) ?
-                            blk2_size :
-                            COAP_BLOCKWISE_SZX_MAX;
-                        if (pkt->block2_size > 10) {
+                        if (blk2_size > 10) {
                             DEBUG("nanocoap: discarding packet with invalid block szx.\n");
                             return -EBADMSG;
                         }
@@ -347,11 +341,6 @@ size_t coap_put_option_block2(uint8_t *buf, uint16_t lastonum, \
     uint8_t szx = coap_blockwise_size2szx(blk->end_pos - blk->start_pos);
     uint16_t num = blk->start_pos/(blk->end_pos - blk->start_pos);
 
-    /* Add header position to struct to adjust "more" later */
-    if (blk->block_hdr == NULL) {
-        blk->block_hdr = buf;
-    }
-
     /* Determine option length */
     if (num > 0x0f) {
         opt_len = 2;
@@ -361,11 +350,8 @@ size_t coap_put_option_block2(uint8_t *buf, uint16_t lastonum, \
     }
 
     tmp = num << COAP_BLOCKWISE_NUM_OFF;
-    if (blk->cur_pos >= blk->end_pos) {
-        tmp |= 1 << COAP_BLOCKWISE_MORE_OFF;
-    }
     tmp |= szx;
-    return coap_put_option(blk->block_hdr, lastonum, COAP_OPT_BLOCK2, 
+    return coap_put_option(buf, lastonum, COAP_OPT_BLOCK2,
                            (uint8_t*)&tmp, opt_len);
 }
 
@@ -405,13 +391,36 @@ size_t coap_put_option_uri(uint8_t *buf, uint16_t lastonum, const char *uri, uin
 
 void coap_blockwise_init(coap_pkt_t *pkt, coap_blockwise_t *blk)
 {
-    blk->start_pos = pkt->block2_num * 1 << pkt->block2_size;
-    blk->end_pos = (pkt->block2_num + 1) * 1 << pkt->block2_size;
+    coap_opt_t opt;
+    coap_find_option(pkt->payload, pkt->options, &opt, COAP_OPT_BLOCK2);
+
+    uint32_t blk2_opt = _decode_uint(opt.val, opt.len);
+    uint32_t blk2_num = blk2_opt >> COAP_BLOCKWISE_NUM_OFF;
+    uint8_t blk2_size = (blk2_opt & COAP_BLOCKWISE_SZX_MASK) + 4;
+    /* Use the smallest block size */
+    blk2_size = (COAP_BLOCKWISE_SZX_MAX > blk2_size) ?
+        blk2_size :
+        COAP_BLOCKWISE_SZX_MAX;
+    blk->start_pos = blk2_num * 1 << blk2_size;
+    blk->end_pos = blk->start_pos + (1 << blk2_size);
     blk->cur_pos = 0;
-    blk->block_hdr = NULL;
 }
 
-size_t coap_blockwise_put_char(uint8_t *bufpos, coap_blockwise_t *blk, char c)
+void coap_finish_option_block2(coap_blockwise_t *blk, uint8_t *options_pos, uint8_t *body_pos)
+{
+    coap_opt_t opt;
+    uint8_t *hdr_pos = coap_find_option(body_pos, options_pos, &opt, COAP_OPT_BLOCK2);
+    if (hdr_pos == NULL) {
+        DEBUG("nanocoap: No block2 header found, unable to adjust more flag");
+        return;
+    }
+    if (blk->cur_pos >= blk->end_pos) {
+        opt.val[opt.len-1] |= 1 << COAP_BLOCKWISE_MORE_OFF;
+    }
+}
+
+
+size_t coap_blockwise_put_char(coap_blockwise_t *blk, uint8_t *bufpos, char c)
 {
     blk->cur_pos++;
     /* Only copy the char if it is within the window */
@@ -422,7 +431,7 @@ size_t coap_blockwise_put_char(uint8_t *bufpos, coap_blockwise_t *blk, char c)
     return 0;
 }
 
-size_t coap_blockwise_put_string(uint8_t *bufpos, coap_blockwise_t *blk, \
+size_t coap_blockwise_put_string(coap_blockwise_t *blk, uint8_t *bufpos, \
                                  const char *c, size_t len)
 {
     uint16_t str_offset = 0;
@@ -465,19 +474,21 @@ ssize_t coap_well_known_core_default_handler(coap_pkt_t* pkt, uint8_t *buf, \
     bufpos += coap_put_option_block2(bufpos, COAP_OPT_CONTENT_FORMAT, &blk);
     *bufpos++ = 0xff;
 
+    uint8_t *body_reply = bufpos;
+
     for (unsigned i = 0; i < coap_resources_numof; i++) {
         if (i) {
-            bufpos += coap_blockwise_put_char(bufpos, &blk, ',');
+            bufpos += coap_blockwise_put_char(&blk, bufpos, ',');
         }
         unsigned url_len = strlen(coap_resources[i].path);
-        bufpos += coap_blockwise_put_char(bufpos, &blk, '<');
-        bufpos += coap_blockwise_put_string(bufpos, &blk, \
+        bufpos += coap_blockwise_put_char(&blk, bufpos, '<');
+        bufpos += coap_blockwise_put_string(&blk, bufpos, \
                                             coap_resources[i].path, url_len);
-        bufpos += coap_blockwise_put_char(bufpos, &blk, '>');
+        bufpos += coap_blockwise_put_char(&blk, bufpos, '>');
     }
 
     unsigned payload_len = bufpos - payload;
-    coap_put_option_block2(bufpos, COAP_OPT_CONTENT_FORMAT, &blk);
+    coap_finish_option_block2(&blk, payload, body_reply);
 
     return coap_build_reply(pkt, COAP_CODE_205, buf, len, payload_len);
 }

--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -413,16 +413,12 @@ void coap_blockwise_init(coap_pkt_t *pkt, coap_blockwise_t *blk)
 
 size_t coap_blockwise_put_char(uint8_t *bufpos, coap_blockwise_t *blk, char c)
 {
-    if (blk->start_pos <=  blk->cur_pos) {
-        if (blk->cur_pos >= blk->end_pos) {
-            blk->cur_pos++;
-            return 0;
-        }
+    blk->cur_pos++;
+    /* Only copy the char if it is within the window */
+    if (blk->start_pos <=  blk->cur_pos && blk->cur_pos < blk->end_pos) {
         *bufpos = c;
-        blk->cur_pos++;
         return 1;
     }
-    blk->cur_pos++;
     return 0;
 }
 

--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -412,7 +412,7 @@ static int _parse_opt(uint8_t *optpos, coap_opt_t *opt)
     return (opt->val - optpos) + opt->len;
 }
 
-uint8_t *coap_find_option(coap_pkt_t *pkt, uint8_t *bufpos,
+uint8_t *coap_find_option(uint8_t *payload_pos, uint8_t *bufpos,
                           coap_opt_t *opt, uint16_t optnum)
 {
     assert(opt);
@@ -425,7 +425,7 @@ uint8_t *coap_find_option(coap_pkt_t *pkt, uint8_t *bufpos,
     uint16_t delta = 0;
 
     do {
-        if (bufpos >= pkt->payload) {
+        if (bufpos >= payload_pos) {
             return NULL;
         }
         int res = _parse_opt(bufpos, opt);

--- a/nanocoap/nanocoap.c
+++ b/nanocoap/nanocoap.c
@@ -50,6 +50,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     }
 
     /* parse options */
+    pkt->options = (pkt_pos != pkt_end) ? pkt_pos : NULL;
     int option_nr = 0;
     while (pkt_pos != pkt_end) {
         uint8_t option_byte = *pkt_pos++;
@@ -107,6 +108,13 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
 
             pkt_pos += option_len;
         }
+    }
+
+    /* set payload pointer to first byte after the options in case no payload
+     * is present, so we can use it as reference to find the end of options
+     * at a later point in time */
+    if (pkt_pos == pkt_end) {
+        pkt->payload = pkt_end;
     }
 
     DEBUG("coap pkt parsed. code=%u detail=%u payload_len=%u, 0x%02x\n",
@@ -368,4 +376,66 @@ ssize_t coap_well_known_core_default_handler(coap_pkt_t* pkt, uint8_t *buf, \
     unsigned payload_len = bufpos - payload;
 
     return coap_build_reply(pkt, COAP_CODE_205, buf, len, payload_len);
+}
+
+size_t get_lenval(uint8_t *buf, uint16_t *val)
+{
+    size_t len = 0;
+
+    if (*val == 13) {
+        *val += *buf;
+        len = 1;
+    }
+    else if (*val == 14) {
+        memcpy(val, buf, 2);
+        *val = htons(*val) + 269;
+        len = 2;
+    }
+
+    return len;
+}
+
+int parse_opt(uint8_t *optpos, coap_opt_t *opt)
+{
+    opt->val = optpos + 1;
+    opt->delta = ((*optpos & 0xf0) >> 4);
+    opt->len =  (*optpos & 0x0f);
+
+    /* make sure delta and len raw values are valid */
+    if ((opt->delta == 15) || (opt->len == 15)) {
+        return -1;
+    }
+
+    opt->val += get_lenval(opt->val, &opt->delta);
+    opt->val += get_lenval(opt->val, &opt->len);
+
+    return (opt->val - optpos) + opt->len;
+}
+
+uint8_t *coap_find_opt(coap_pkt_t *pkt, uint8_t *bufpos,
+                       coap_opt_t *opt, uint16_t optnum)
+{
+    assert(opt);
+
+    /* check if we reached the end of options */
+    if (!bufpos || (*bufpos == 0xff) || (bufpos == pkt->payload)) {
+        return NULL;
+    }
+
+    uint16_t delta = 0;
+
+    do {
+        int res = parse_opt(bufpos, opt);
+        if (res < 0) {
+            return NULL;
+        }
+        bufpos += res;
+        delta += opt->delta;
+    } while (delta < optnum);
+
+    if (delta != optnum) {
+        bufpos = NULL;
+    }
+
+    return bufpos;
 }

--- a/nanocoap/nanocoap.h
+++ b/nanocoap/nanocoap.h
@@ -161,8 +161,6 @@ typedef struct {
     unsigned payload_len;
     uint16_t content_type;
     uint32_t observe_value;
-    uint32_t block2_num;
-    uint32_t block2_size;
 } coap_pkt_t;
 
 typedef ssize_t (*coap_handler_t)(coap_pkt_t* pkt, uint8_t *buf, size_t len);
@@ -183,7 +181,6 @@ typedef struct {
     uint32_t start_pos;
     uint32_t cur_pos;
     uint16_t end_pos;
-    uint8_t *block_hdr;
 } coap_blockwise_t;
 
 extern const coap_resource_t coap_resources[];

--- a/nanocoap/nanocoap.h
+++ b/nanocoap/nanocoap.h
@@ -17,6 +17,8 @@
 #define COAP_OPT_URI_PATH       (11)
 #define COAP_OPT_CONTENT_FORMAT (12)
 #define COAP_OPT_URI_QUERY      (15)
+#define COAP_OPT_BLOCK2         (23)
+#define COAP_OPT_BLOCK1         (27)
 
 #define COAP_REQ                (0)
 #define COAP_RESP               (2)
@@ -66,6 +68,7 @@
 #define COAP_CODE_CHANGED      ((2<<5) | 4)
 #define COAP_CODE_CONTENT      ((2<<5) | 5)
 #define COAP_CODE_205          ((2<<5) | 5)
+#define COAP_CODE_CONTINUE     ((2<<5) | 31)
 /** @} */
 /**
  * @name Response message codes: client error
@@ -80,6 +83,7 @@
 #define COAP_CODE_404                        ((4<<5) | 4)
 #define COAP_CODE_METHOD_NOT_ALLOWED         ((4<<5) | 5)
 #define COAP_CODE_NOT_ACCEPTABLE             ((4<<5) | 6)
+#define COAP_CODE_REQ_ENTITY_INCOMPLETE      ((4<<5) | 8)
 #define COAP_CODE_PRECONDITION_FAILED        ((4<<5) | 0xC)
 #define COAP_CODE_REQUEST_ENTITY_TOO_LARGE   ((4<<5) | 0xD)
 #define COAP_CODE_UNSUPPORTED_CONTENT_FORMAT ((4<<5) | 0xF)

--- a/nanocoap/nanocoap.h
+++ b/nanocoap/nanocoap.h
@@ -204,6 +204,12 @@ size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum, uint16_t content_type
 size_t coap_put_option_block2(uint8_t *buf, uint16_t lastonum, coap_blockwise_t *blk);
 size_t coap_put_option_uri(uint8_t *buf, uint16_t lastonum, const char *uri, uint16_t optnum);
 
+void coap_blockwise_init(coap_pkt_t *pkt, coap_blockwise_t *blk);
+void coap_finish_option_block2(coap_blockwise_t *blk, uint8_t *options_pos, uint8_t *body_pos);
+
+size_t coap_blockwise_put_char(coap_blockwise_t *blk, uint8_t *bufpos, char c);
+size_t coap_blockwise_put_string(coap_blockwise_t *blk, uint8_t *bufpos, const char *c, size_t len);
+
 uint8_t *coap_find_option(uint8_t *payload_pos, uint8_t *bufpos, coap_opt_t *opt, uint16_t optnum);
 
 static inline unsigned coap_get_ver(coap_pkt_t *pkt)

--- a/nanocoap/nanocoap.h
+++ b/nanocoap/nanocoap.h
@@ -180,7 +180,7 @@ typedef struct {
 typedef struct {
     uint32_t start_pos;
     uint32_t cur_pos;
-    uint16_t end_pos;
+    uint32_t end_pos;
 } coap_blockwise_t;
 
 extern const coap_resource_t coap_resources[];

--- a/nanocoap/nanocoap.h
+++ b/nanocoap/nanocoap.h
@@ -183,7 +183,7 @@ size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, uint8_t *
 size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum, uint16_t content_type);
 size_t coap_put_option_uri(uint8_t *buf, uint16_t lastonum, const char *uri, uint16_t optnum);
 
-uint8_t *coap_find_opt(coap_pkt_t *pkt, uint8_t *bufpos, coap_opt_t *opt, uint16_t optnum);
+uint8_t *coap_find_option(coap_pkt_t *pkt, uint8_t *bufpos, coap_opt_t *opt, uint16_t optnum);
 
 static inline unsigned coap_get_ver(coap_pkt_t *pkt)
 {

--- a/nanocoap/nanocoap.h
+++ b/nanocoap/nanocoap.h
@@ -13,6 +13,7 @@
 
 #define COAP_OPT_URI_HOST       (3)
 #define COAP_OPT_OBSERVE        (6)
+#define COAP_OPT_LOCATION_PATH  (8)
 #define COAP_OPT_URI_PATH       (11)
 #define COAP_OPT_CONTENT_FORMAT (12)
 #define COAP_OPT_URI_QUERY      (15)
@@ -141,6 +142,7 @@ typedef struct {
     uint8_t url[NANOCOAP_URL_MAX];
     uint8_t qs[NANOCOAP_QS_MAX];
     uint8_t *token;
+    uint8_t *options;
     uint8_t *payload;
     unsigned payload_len;
     uint16_t content_type;
@@ -154,6 +156,12 @@ typedef struct {
     unsigned methods;
     coap_handler_t handler;
 } coap_resource_t;
+
+typedef struct {
+    uint16_t delta;
+    uint16_t len;
+    uint8_t *val;
+} coap_opt_t;
 
 extern const coap_resource_t coap_resources[];
 extern const unsigned coap_resources_numof;
@@ -174,6 +182,8 @@ ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, uint8_t *token, size_t to
 size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, uint8_t *odata, size_t olen);
 size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum, uint16_t content_type);
 size_t coap_put_option_uri(uint8_t *buf, uint16_t lastonum, const char *uri, uint16_t optnum);
+
+uint8_t *coap_find_opt(coap_pkt_t *pkt, uint8_t *bufpos, coap_opt_t *opt, uint16_t optnum);
 
 static inline unsigned coap_get_ver(coap_pkt_t *pkt)
 {

--- a/nanocoap/nanocoap.h
+++ b/nanocoap/nanocoap.h
@@ -183,7 +183,7 @@ size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, uint8_t *
 size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum, uint16_t content_type);
 size_t coap_put_option_uri(uint8_t *buf, uint16_t lastonum, const char *uri, uint16_t optnum);
 
-uint8_t *coap_find_option(coap_pkt_t *pkt, uint8_t *bufpos, coap_opt_t *opt, uint16_t optnum);
+uint8_t *coap_find_option(uint8_t *payload_pos, uint8_t *bufpos, coap_opt_t *opt, uint16_t optnum);
 
 static inline unsigned coap_get_ver(coap_pkt_t *pkt)
 {


### PR DESCRIPTION
This PR adds block2 support for nanocoap. This facilitates larger transfers such as a large /.well-know/core payload.

I've tried to make it as easy as possible for a handler to support blockwise transfer. As an example I rewrote the /.well-known/core handler with block2 support.

I've added two extra fields to the `coap_pkt_t` struct, but with #18 merged, it should be possible to remove these fields.