### PR TITLE
Update for nanocoap resource context

### DIFF
--- a/nanocoap/handler.c
+++ b/nanocoap/handler.c
@@ -3,8 +3,10 @@
 
 #include "net/nanocoap.h"
 
-ssize_t _test_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len)
+ssize_t _test_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, void *context)
 {
+    (void)context;
+
     printf("_test_handler()\n");
     printf("coap pkt parsed. code=%u detail=%u payload_len=%u, len=%u 0x%02x\n",
             coap_get_code_class(pkt),
@@ -17,7 +19,7 @@ ssize_t _test_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len)
 
 const coap_resource_t coap_resources[] = {
     COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER,
-    { "/test", COAP_GET, _test_handler },
+    { "/test", COAP_GET, _test_handler, NULL },
 };
 
 const unsigned coap_resources_numof = sizeof(coap_resources) / sizeof(coap_resources[0]);


### PR DESCRIPTION
Update nancooap test handler for server resource context parameter. Update to latest RIOT master commit.

I did *not* test the impact of the RIOT update on other aspects of sock. Let me know if there is anything else I should check.